### PR TITLE
Revert "Syncing upstream to fork"

### DIFF
--- a/renderapps/dataimport/add_downsample_to_render_project.py
+++ b/renderapps/dataimport/add_downsample_to_render_project.py
@@ -1,7 +1,7 @@
 import os
 from create_mipmaps import create_mipmaps
 import renderapi
-from renderapi.image_pyramid import MipMap
+from renderapi.tilespec import MipMapLevel
 from functools import partial
 from ..module.render_module import RenderModule, RenderParameters
 from argschema.fields import Str, Boolean, Int
@@ -38,7 +38,7 @@ def make_tilespecs_and_cmds(render,inputStack,outputStack):
         tilespecs = render.run(renderapi.tilespec.get_tile_specs_from_z,inputStack,z)
 
         for i,tilespec in enumerate(tilespecs):
-            mml = tilespec.ip[0]
+            mml = tilespec.ip.mipMapLevels[0]
 
             old_url = mml.imageUrl
             filepath=str(old_url).lstrip('file:')
@@ -60,8 +60,8 @@ def make_tilespecs_and_cmds(render,inputStack,outputStack):
             downdir2 = downdir.replace(" ", "%20")
             for i in range(1, 4):
                 scUrl = 'file:' + os.path.join(downdir2,filename[0:-4]+'_mip0%d.jpg'%i)
-                mml = MipMap(imageUrl=scUrl)
-                tilespec.ip[i]=mml
+                mml = MipMapLevel(level=i,imageUrl=scUrl)
+                tilespec.ip.update(mml)
 
         tempjson = tempfile.NamedTemporaryFile(
             suffix=".json", mode='r', delete=False)

--- a/renderapps/dataimport/add_downsample_to_render_project_v3.py
+++ b/renderapps/dataimport/add_downsample_to_render_project_v3.py
@@ -2,7 +2,7 @@ import json
 import os
 from create_mipmaps import create_mipmaps
 import renderapi
-from renderapi.image_pyramid import MipMapLevel
+from renderapi.tilespec import MipMapLevel
 import argparse
 from functools import partial
 from ..module.render_module import RenderModule, RenderParameters


### PR DESCRIPTION
Reverts TotteKarlsson/render-python-apps#1

This broke create fast stacks scripts saying:
docker exec renderapps python -m renderapps.dataimport.create_fast_stacks --render.host W10DTMJ03EG6Z.corp.alleninstitute.org --render.client_scripts /shared/render/render-ws-java-client/src/main/scripts --render.port 8080 --render.memGB 5G --log_level INFO --statetableFile /mnt/data/M33/scripts/statetable_ribbon_4_session_2_section_0 --render.project M33 --projectDirectory /mnt/data/M33 --outputStackPrefix ACQ_S02 --render.owner TestOwner
b'/opt/conda/lib/python2.7/site-packages/scipy/linalg/basic.py:17: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88\n'
b'  from ._solve_toeplitz import levinson\n'
b'/opt/conda/lib/python2.7/site-packages/scipy/linalg/__init__.py:207: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88\n'
b'  from ._decomp_update import *\n'
b'/opt/conda/bin/python: cannot import name MipMapLevel\n'